### PR TITLE
FIX: Fixing issue that causes the notifier to freeze visual studio when sendng to slack

### DIFF
--- a/PublishNotifier/Services/SlackService.cs
+++ b/PublishNotifier/Services/SlackService.cs
@@ -1,27 +1,34 @@
 ﻿using Slack.Webhooks;
 using System;
+using System.Threading.Tasks;
 using System.Windows;
 
 namespace PublishNotifier
 {
     public class SlackService : IDisposable
     {
+        private SlackClient Client;
+        private SlackMessage Message;
         public SlackService(string slackWebhookUrl, string projectName)
         {
             try
             {
-                var slackClient = new SlackClient(slackWebhookUrl);
-                var slackMessage = new SlackMessage
+                Client = new SlackClient(slackWebhookUrl);
+                Message = new SlackMessage
                 {
                     Text = $"{projectName} was just published!",
                     Username = "PublishNotifier"
                 };
-                slackClient.Post(slackMessage);
             }
             catch (Exception ex)
             {
                 MessageBox.Show(ex.Message, "Slack Webhook URL");
             }
+        }
+
+        public async Task<bool> SendMessage()
+        {
+            return await Client.PostAsync(Message);
         }
 
         public void Dispose()

--- a/PublishNotifier/Services/SlackService.cs
+++ b/PublishNotifier/Services/SlackService.cs
@@ -7,14 +7,15 @@ namespace PublishNotifier
 {
     public class SlackService : IDisposable
     {
-        private SlackClient Client;
-        private SlackMessage Message;
+        private readonly SlackClient _client;
+        private readonly SlackMessage _message;
+
         public SlackService(string slackWebhookUrl, string projectName)
         {
             try
             {
-                Client = new SlackClient(slackWebhookUrl);
-                Message = new SlackMessage
+                _client = new SlackClient(slackWebhookUrl);
+                _message = new SlackMessage
                 {
                     Text = $"{projectName} was just published!",
                     Username = "PublishNotifier"
@@ -26,10 +27,7 @@ namespace PublishNotifier
             }
         }
 
-        public async Task<bool> SendMessage()
-        {
-            return await Client.PostAsync(Message);
-        }
+        public async Task<bool> SendMessage() => await _client.PostAsync(_message);
 
         public void Dispose()
         {

--- a/PublishNotifier/VSPackage.cs
+++ b/PublishNotifier/VSPackage.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using EnvDTE80;
 using EnvDTE;
+using System.Threading.Tasks;
 
 namespace PublishNotifier
 {
@@ -31,7 +32,7 @@ namespace PublishNotifier
             publishEvents.OnPublishDone += PublishEvents_OnPublishDone;
         }
 
-        private void PublishEvents_OnPublishDone(bool Success)
+        private async void PublishEvents_OnPublishDone(bool Success)
         {
             using (var publishedProjectService = new PublishedProjectService(application))
             {
@@ -48,7 +49,7 @@ namespace PublishNotifier
             }
         }
 
-        private void Dialog_Closing(PublishedProjectService publishedProjectService, ConfigurationService configurationService, object sender, System.ComponentModel.CancelEventArgs e)
+        private async System.Threading.Tasks.Task Dialog_Closing(PublishedProjectService publishedProjectService, ConfigurationService configurationService, object sender, System.ComponentModel.CancelEventArgs e)
         {
             if (sender != null && sender is PublishNotifierDialog)
             {
@@ -61,6 +62,7 @@ namespace PublishNotifier
                     {
                         using (var slackService = new SlackService(publishNotifierDialog.configurationModel.slackWebhookUrl, publishedProjectService.GetProjectName()))
                         {
+                            bool success = await slackService.SendMessage();
                         }
                     }
 

--- a/PublishNotifier/VSPackage.cs
+++ b/PublishNotifier/VSPackage.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using EnvDTE80;
 using EnvDTE;
-using System.Threading.Tasks;
 
 namespace PublishNotifier
 {
@@ -32,7 +31,7 @@ namespace PublishNotifier
             publishEvents.OnPublishDone += PublishEvents_OnPublishDone;
         }
 
-        private async void PublishEvents_OnPublishDone(bool Success)
+        private void PublishEvents_OnPublishDone(bool Success)
         {
             using (var publishedProjectService = new PublishedProjectService(application))
             {
@@ -42,7 +41,7 @@ namespace PublishNotifier
                     using (var configurationService = new ConfigurationService(selectedItem, publishedProjectService.GetConfigurationFileFullPath()))
                     {
                         PublishNotifierDialog dialog = new PublishNotifierDialog(configurationService.GetConfigurationModel());
-                        dialog.Closing += (sender, e) => Dialog_Closing(publishedProjectService, configurationService, sender, e);
+                        dialog.Closing += async (sender, e) => await Dialog_Closing(publishedProjectService, configurationService, sender, e);
                         dialog.ShowModal();
                     }
                 }


### PR DESCRIPTION
This commit aims to fix the issue brought up here: https://github.com/dalibormesaric/PublishNotifier/issues/2 . I believe the issue was being caused by the slack webhook client deadlocking similar to this issue: https://github.com/mrb0nj/Slack.Webhooks/issues/81 . Managed to resolve the issue by using the async version of the post function.